### PR TITLE
Remove activity references for RN@0.29.0

### DIFF
--- a/android/src/main/java/com/robinpowered/react/battery/DeviceBatteryModule.java
+++ b/android/src/main/java/com/robinpowered/react/battery/DeviceBatteryModule.java
@@ -1,6 +1,5 @@
 package com.robinpowered.react.battery;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
@@ -31,7 +30,7 @@ public class DeviceBatteryModule extends ReactContextBaseJavaModule
   private @Nullable PowerConnectionReceiver batteryStateReceiver;
 
 
-  public DeviceBatteryModule(ReactApplicationContext reactApplicationContext, Activity activity) {
+  public DeviceBatteryModule(ReactApplicationContext reactApplicationContext) {
     super(reactApplicationContext);
   }
 

--- a/android/src/main/java/com/robinpowered/react/battery/DeviceBatteryPackage.java
+++ b/android/src/main/java/com/robinpowered/react/battery/DeviceBatteryPackage.java
@@ -14,16 +14,10 @@ import java.util.Collections;
 import java.util.List;
 
 public class DeviceBatteryPackage implements ReactPackage {
-  private Activity mActivity = null;
-
-  public DeviceBatteryPackage(Activity activity) {
-    mActivity = activity;
-  }
-
   @Override
   public List<NativeModule> createNativeModules(ReactApplicationContext reactApplicationContext) {
     List<NativeModule> modules = new ArrayList<NativeModule>();
-    modules.add(new DeviceBatteryModule(reactApplicationContext, mActivity));
+    modules.add(new DeviceBatteryModule(reactApplicationContext));
     return modules;
   }
 


### PR DESCRIPTION
Activities are no longer injected in RN `0.29.0` and later. This component also no longer used the `Activity`
