### PR TITLE
Fix breaking change w/ Gradle dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,13 +10,17 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion safeExtGet('compileSdkVersion', '23')
+    buildToolsVersion safeExtGet('buildToolsVersion', '23.0.1')
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion safeExtGet('minSdkVersion', '16')
+        targetSdkVersion safeExtGet('targetSdkVersion', '22')
         versionCode 1
         versionName "1.0"
     }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,5 +30,5 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.15.+'
+    implementation 'com.facebook.react:react-native:0.15.+'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-device-battery",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Observe battery state changes in your react native application",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Intent
This fixes a breaking API change with the Android Gradle plugin, which was deprecated as of version 3.0.0 and later made obsolete. 

## Changes
When adding Gradle dependencies, the `compile` command has been removed and replaced with `implementation`/`api`.

The Gradle file also now provides flexibility for SDK versions.

## More information
- [Gradle support docs](https://docs.gradle.org/5.4.1/userguide/java_library_plugin.html#sec:java_library_separation)
- [Android deprecation doc](https://developer.android.com/studio/build/dependencies?utm_source=android-studio#dependency_configurations)